### PR TITLE
Use the `port` value provided in config.json to build the web hook URL

### DIFF
--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -126,7 +126,15 @@ module.exports = function bootstrap(options) {
     var repo_info = app.buildRepoInfo(repo_fullname)
       , options
       , hook_names = _.keys(repo_options.hooks)
-      , url_params = '?repo_fullname=' + repo_fullname;
+      , url_params = '?repo_fullname=' + repo_fullname
+      , url_port = process.env.PORT || bot.options.port
+      , url_obj = url.parse(bot.options.url);
+
+    url_obj.search = url_params;
+    if (!url_obj.port) {
+      url_obj.port = url_port;
+      url_obj.host = null;
+    }
 
     _.each(repo_options.hooks, function (scripts, cron) {
       app.resolveScripts(scripts, 'scripts/hooks/');
@@ -140,7 +148,7 @@ module.exports = function bootstrap(options) {
     , name: 'web'
     , active: true
     , events: hook_names
-    , config: {url: bot.options.url + url_params, content_type: 'json'}
+    , config: {url: url.format(url_obj), content_type: 'json'}
     };
 
     bot.github.repos.createHook(options, function (error, data) {


### PR DESCRIPTION
app.initializeHooks does not take bot.options.port into account when it builds the GitHub web hook URL. For example, if bot.options.port === 5000 and bot.options.url === 'http://foo.com', the hook url will be http://foo.com?repo_fullname=user/reponame. This patch uses bot.options.port, only if a port is not already part of bot.options.url.