### PR TITLE
Allow botdylan to use oAuth authentication to the GitHub API as an alternative to basic auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ Configuring botdylan is damn simple! Just populate your `config.json` file on yo
 configuration directory with the following options:
 
   * `username`: Bot username
-  * `password`: Bot password
+  * `password`: Bot password or oauth token
+  * `auth [basic]`: Auth type to use when connecting to GitHub. Can be `basic` (username/password) or `oauth` (username/token)
   * `repositories`: Hash of repositories (owner/repository) with the `cron` and `hooks` setted up
   * `port [80]`: Port to listen github webhooks
   * `silent [false]`: Flag to disable output

--- a/bin/botdylan.js
+++ b/bin/botdylan.js
@@ -6,7 +6,7 @@ var program = require('commander')
   , config_file
   , config_options
   , app_options
-  , default_options = {silent: false, port: 80};
+  , default_options = {silent: false, port: 80, auth: 'basic'};
 
 GLOBAL._ = require('underscore');
 

--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -38,11 +38,16 @@ module.exports = function bootstrap(options) {
    * GitHub Authentication
    */
   app.authenticate = function () {
-    bot.github.authenticate({
-      type: 'basic'
-    , username: bot.options.username
-    , password: bot.options.password
-    });
+    var options = {
+      type: bot.options.auth,
+      username: bot.options.password
+    };
+    if (bot.options.auth === 'basic') {
+      options.password = bot.options.password;
+    } else if (bot.options.auth === 'oauth') {
+      options.token = bot.options.password;
+    }
+    bot.github.authenticate(options);
   };
 
   /**


### PR DESCRIPTION
Basic auth is the default, but the user can specify `"auth": "oauth"` and
`"password": "OAUTH_TOKEN"` in config.json to use oauth.
