### PR TITLE
Set (optional) secret to secure webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,13 @@ configuration directory with the following options:
   * `repositories`: Hash of repositories (owner/repository) with the `cron` and `hooks` setted up
   * `port [80]`: Port to listen github webhooks
   * `silent [false]`: Flag to disable output
+  * `secret`: (*Optional*) String with high entropy to [secure your webhook](https://developer.github.com/webhooks/securing/#securing-your-webhooks)
 
 ``` javascript
 {
   "username": "botdylan"
 , "password": "blood-on-the-tracks"
+, "secret": "myhashsecret"
 , "url": "http://example.com"
 , "port": 5000
 , "repositories": {

--- a/bin/botdylan.js
+++ b/bin/botdylan.js
@@ -25,4 +25,8 @@ console.log('* Configuration path: ' + config_file);
 config_options = require('cjson').load(config_file);
 app_options = _.extend(default_options, config_options);
 
+if (!app_options.secret) {
+  console.log('* No secret specified! Your webhook may be insecure: https://developer.github.com/webhooks/securing/');
+}
+
 require('../lib/bootstrap')(app_options);

--- a/example.config.json
+++ b/example.config.json
@@ -1,6 +1,7 @@
 {
   "username": ""
 , "password": ""
+, "secret": ""
 , "url": ""
 , "port": 5000
 , "repositories": {

--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -2,6 +2,7 @@ module.exports = function bootstrap(options) {
   var _ = require('underscore')
     , GitHubApi = require('github')
     , http = require('http')
+    , crypto = require('crypto')
     , url = require('url')
     , fs = require('fs')
     , path = require('path')
@@ -130,6 +131,7 @@ module.exports = function bootstrap(options) {
 
     var repo_info = app.buildRepoInfo(repo_fullname)
       , options
+      , config
       , hook_names = _.keys(repo_options.hooks)
       , url_params = '?repo_fullname=' + repo_fullname;
 
@@ -139,13 +141,19 @@ module.exports = function bootstrap(options) {
 
     bot.trace('* Creating remote hooks ' + hook_names.join(', ') + ' in ' + repo_fullname);
 
+    config = {url: bot.options.url + url_params, content_type: 'json'}
+
+    if (bot.options.secret) {
+      config.secret = bot.options.secret;
+    }
+
     options = {
       user: repo_info.owner
     , repo: repo_info.name
     , name: 'web'
     , active: true
     , events: hook_names
-    , config: {url: bot.options.url + url_params, content_type: 'json'}
+    , config: config
     };
 
     bot.github.repos.createHook(options, function (error, data) {
@@ -176,15 +184,28 @@ module.exports = function bootstrap(options) {
 
         var url_params = url.parse(this.url, true)
           , hook_name = this.headers['x-github-event']
+          , sig = this.headers['x-hub-signature']
           , repo_fullname = url_params.query.repo_fullname
           , repo_info;
+
+        if (bot.options.secret) {
+          if (!sig) {
+            console.error('* [ERROR] No X-Hub-Signature found on request');
+            return;
+          } else if (sig !== signBlob(bot.options.secret, data)) {
+            console.error('* [ERROR] X-Hub-Signature does not match blob signature');
+            return;
+          } else {
+            bot.trace('* [INFO] Sig match found');
+          }
+        }
 
         if (_.isUndefined(repo_fullname)) {
           console.error('* [ERROR] Wrong hook url: ' + this.url);
           return;
         }
 
-        bot.trace('* [INFO] New incomming \'' + hook_name + '\' hook from: ' + repo_fullname);
+        bot.trace('* [INFO] New incoming \'' + hook_name + '\' hook from: ' + repo_fullname);
 
         repo_info = app.buildRepoInfo(repo_fullname);
         runHook(bot, hook_name, repo_info, repo_fullname, data);
@@ -194,6 +215,10 @@ module.exports = function bootstrap(options) {
     bot.trace('\nServer listening on port ' + port);
     server.listen(port);
   };
+
+  function signBlob (key, blob) {
+    return 'sha1=' + crypto.createHmac('sha1', key).update(blob).digest('hex');
+  }
 
   app.initialize();
 };

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "cjson": "0.2.1",
     "underscore": "1.5.1",
     "github": "0.1.8",
+    "crypto": "0.0.3",
     "cron": "1.0.1",
     "request": "2.25.0"
   },


### PR DESCRIPTION
I added an option for securing the webhook based on [GitHub's suggested approach](https://developer.github.com/webhooks/securing/) and this [node implementation](https://github.com/rvagg/github-webhook-handler) & updated the README.

Please let me know if there's anything I can do to improve this, I am new to nodejs but always willing to learn more. I have tested this out with a PR-commenter I scripted and it appears to work exactly as expected. I was even able to test the negative case by manually updating the webhook after it was auto-generated with a different password, and the node server correctly rejected the next POST from GitHub.