### PR TITLE
Add support for GitHub Enterprise

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ configuration directory with the following options:
   * `port [80]`: Port to listen github webhooks
   * `silent [false]`: Flag to disable output
   * `secret`: (*Optional*) String with high entropy to [secure your webhook](https://developer.github.com/webhooks/securing/#securing-your-webhooks)
+  * `github_api`: (*Optional*) Object with options directly to `GitHubApi` constructor, see [npm's github docs](https://www.npmjs.com/package/github)
 
 ``` javascript
 {
@@ -77,7 +78,11 @@ configuration directory with the following options:
         "issue_comment": ["pong"]
       , "push" : ["cowboys"]
       }
-    }
+    }  
+  }
+, "github_api": {
+     "host": "my-enterprise-github-instance.mycompany.com" // if you're using GitHub Enterprise,
+     "timeout": 2000
   }
 }
 ```

--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -18,7 +18,7 @@ module.exports = function bootstrap(options) {
   , handleError: require('./bot/handleError')(options)
   , store: require('./bot/store')
   , events: require('./bot/events')
-  , github: new GitHubApi({version: '3.0.0'})
+  , github: new GitHubApi(_.extend({version: '3.0.0'}, options.github_api))
   , http: request
   };
 


### PR DESCRIPTION
I wanted to use `botdylan` for company I'm working on right now, but realised that it doesn't support GitHub Enterprise. Now it does.

Also, passing `github_api` options to `GitHubApi` constructor allows you to configure debug mode or different path/timeout. 