### PR TITLE
Add support for ENV variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,16 @@ Scripts under `scripts/hooks` will run on any given [hook event](http://develope
 
 Scripts under `scripts/crons` use the `cron` syntax.
 
+## Environment variables
+
+Sometimes you might not want to store your GitHub credentials inside repository. In order to prevent this you can use three environment variables: `GITHUB_USERNAME`, `GITHUB_PASSWORD`, `GITHUB_WEBHOOK_SECRET` - when set they will overwrite `username`, `password`, `secret` config options.
+
+Example:
+
+```
+GITHUB_USERNAME=johndoe GITHUB_PASSWORD=qwerty GITHUB_WEBHOOK_SECRET=bazinga botdylan --dir /etc/botdylan
+```
+
 ## How to write `botdylan` scripts?
 
 The scripts have to export a single function that will be executed by

--- a/bin/botdylan.js
+++ b/bin/botdylan.js
@@ -5,6 +5,7 @@ var program = require('commander')
   , path = require('path')
   , config_file
   , config_options
+  , env_options
   , app_options
   , default_options = {silent: false, port: 80, auth: 'basic'};
 
@@ -23,7 +24,12 @@ console.log('* Scripts path: ' + default_options.dir);
 console.log('* Configuration path: ' + config_file);
 
 config_options = require('cjson').load(config_file);
-app_options = _.extend(default_options, config_options);
+env_options = {
+  username: process.env.GITHUB_USERNAME || '',
+  password: process.env.GITHUB_PASSWORD || '',
+  secret: process.env.GITHUB_WEBHOOK_SECRET || ''
+}
+app_options = _.extend(default_options, config_options, env_options);
 
 if (!app_options.secret) {
   console.log('* No secret specified! Your webhook may be insecure: https://developer.github.com/webhooks/securing/');


### PR DESCRIPTION
Sometimes you might not want to store your GitHub credentials inside repository. In order to prevent this you can use three environment variables: `GITHUB_USERNAME`, `GITHUB_PASSWORD`, `GITHUB_WEBHOOK_SECRET` - when set they will overwrite `username`, `password`, `secret` config options.

Example:

```
GITHUB_USERNAME=johndoe GITHUB_PASSWORD=qwerty \ 
GITHUB_WEBHOOK_SECRET=bazinga botdylan --dir /etc/botdylan
```