### PR TITLE
Fix intermittent webhook failures

### DIFF
--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -172,10 +172,10 @@ module.exports = function bootstrap(options) {
       , port = process.env.PORT || bot.options.port;
 
     server = http.createServer(function (request, response) {
-      var data = '';
+      var data = new Buffer(0);
 
       request.on('data', function (chunk) {
-        data += chunk;
+        data = Buffer.concat([data, chunk]);
       });
 
       request.on('end', function () {
@@ -212,7 +212,7 @@ module.exports = function bootstrap(options) {
         bot.trace('* [INFO] New incoming \'' + hook_name + '\' hook from: ' + repo_fullname);
 
         repo_info = app.buildRepoInfo(repo_fullname);
-        runHook(bot, hook_name, repo_info, repo_fullname, data);
+        runHook(bot, hook_name, repo_info, repo_fullname, data.toString('utf8'));
       });
     });
 

--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -179,9 +179,6 @@ module.exports = function bootstrap(options) {
       });
 
       request.on('end', function () {
-        response.writeHead(200);
-        response.end();
-
         var url_params = url.parse(this.url, true)
           , hook_name = this.headers['x-github-event']
           , sig = this.headers['x-hub-signature']
@@ -191,14 +188,21 @@ module.exports = function bootstrap(options) {
         if (bot.options.secret) {
           if (!sig) {
             console.error('* [ERROR] No X-Hub-Signature found on request');
+            response.writeHead(403);
+            response.end("No signature provided");
             return;
           } else if (sig !== signBlob(bot.options.secret, data)) {
             console.error('* [ERROR] X-Hub-Signature does not match blob signature');
+            response.writeHead(400);
+            response.end("Bad signature");
             return;
           } else {
             bot.trace('* [INFO] Sig match found');
           }
         }
+
+        response.writeHead(200);
+        response.end();
 
         if (_.isUndefined(repo_fullname)) {
           console.error('* [ERROR] Wrong hook url: ' + this.url);


### PR DESCRIPTION
Some webhooks were failing with `* [ERROR] X-Hub-Signature does not match blob signature`; it seems this is because the signature was being ran against the stringified received data rather than the raw (`Buffer`) data.

This PR fixes that, and further changes the response code to the bot so that if requests fail they will show up in GitHub's webhook information as failed requests (with a reason).